### PR TITLE
explicit route page refresh when nextjs router isReady

### DIFF
--- a/pages/route.tsx
+++ b/pages/route.tsx
@@ -1,9 +1,9 @@
-import Head           from 'next/head';
-import { useRouter }  from 'next/router';
-import DeliveriesList from '@/components/deliveries-list';
-import Header         from '@/components/header';
-import styles         from '../styles/Home.module.css';
+import Head                    from 'next/head';
+import { useRouter }           from 'next/router';
 import { useEffect, useState } from 'react';
+import DeliveriesList          from '@/components/deliveries-list';
+import Header                  from '@/components/header';
+import styles                  from '../styles/Home.module.css';
 
 /**
  * The app's route page, i.e., the '/route' path

--- a/pages/route.tsx
+++ b/pages/route.tsx
@@ -3,6 +3,7 @@ import { useRouter }  from 'next/router';
 import DeliveriesList from '@/components/deliveries-list';
 import Header         from '@/components/header';
 import styles         from '../styles/Home.module.css';
+import { useEffect, useState } from 'react';
 
 /**
  * The app's route page, i.e., the '/route' path
@@ -16,14 +17,19 @@ const RoutePage = () => {
     baseUrl = `${ getUrl.protocol  }//${  getUrl.host }`;
   }
 
-  const router = useRouter();
-  const query  = router.query;
+  const { query, isReady }              = useRouter();
+  const [ queryValues, setQueryValues ] = useState(query);
 
-  const { date, ref, passcode } = query;
+  useEffect(() => {
+    if (isReady) {
+      setQueryValues(query);
+      console.log('values found, refreshing!');
+    }
+  }, [ query, isReady ]);
 
-  let { mode } = query;
+  const { date, ref, passcode } = queryValues;
 
-  mode = mode || 'bicycling';
+  const mode = queryValues.mode || 'bicycling';
 
   if (!date || !ref || !passcode) {
     return (<div>Oh no! Missing one or more required query parameters</div>);

--- a/pages/route.tsx
+++ b/pages/route.tsx
@@ -23,7 +23,6 @@ const RoutePage = () => {
   useEffect(() => {
     if (isReady) {
       setQueryValues(query);
-      console.log('values found, refreshing!');
     }
   }, [ query, isReady ]);
 


### PR DESCRIPTION
Received a report of the app getting stuck on the "Oh no! Missing one or more required query parameters." page on firefox on Android 12.

This is triggered when the `router.query` values are undefined, which can still happen after the component is loaded but before hydration. NextJS docs claim that:

> During prerendering, the router's `query` object will be empty since we do not have query information to provide during this phase. After hydration, Next.js will trigger an update to your application to provide the route parameters in the `query` object.

and 

> To be able to distinguish if the query is fully updated and ready for use, you can leverage the `isReady` field on `router`.

Throttling the network confirms the bug report, but frustratingly the first quoted statement only seems to be sometimes true? Occasionally the "oh no!" message would show up and a few seconds later the app refresh itself with the route data, but occasionally it would stay on the error page without refreshing like the original report.

Regardless, I moved the query values into state and initialised them in a `useEffect` that depends on `router.query` and the`router.isReady` so that they are explicitly set when the values are available, and testing afterwards confirmed 100% of the time the page refreshed. Hopefully this should fix the issue even for people with crappy connections.