### PR TITLE
Unique (deduplicated) plus codes for waypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ sudo apt -y install git nodejs mysql-server
 # Clone the repo and install dependencies
 
 ```console
-git clone https://github.com/agolden/cck-volunteer-app
-cd cck-volunteer-app
+git clone https://github.com/agolden/cck-volunteer-web-app
+cd cck-volunteer-web-app
 npm install
 ```
 

--- a/components/deliveries-list/DeliveriesList.jsx
+++ b/components/deliveries-list/DeliveriesList.jsx
@@ -88,7 +88,7 @@ const DeliveriesList = ({ date, id_ref: idRef, passcode, mode, basePath }) => {
   const formattedDate = `${ (rDate.getDate() > 9) ? rDate.getDate() : (`0${  rDate.getDate() }`)  }/${  (rDate.getMonth() > 8) ? (rDate.getMonth() + 1) : (`0${  rDate.getMonth() + 1 }`)  }/${  rDate.getFullYear() }`;
 
   const googleRouteBaseUrl = 'https://www.google.com/maps/dir';
-  const plusCodes          = routeData.deliveries.map(item => addPlusCodePrefix(item.plus_code));
+  const plusCodes          = [...new Set(routeData.deliveries.map(item => addPlusCodePrefix(item.plus_code)))];
   const originForUrl       = encodeURIComponent('The Lockon, Fair Street, Cambridge');
   const googleRouteUrl     = `${ googleRouteBaseUrl }/?api=1&origin=${
     originForUrl

--- a/components/deliveries-list/DeliveriesList.jsx
+++ b/components/deliveries-list/DeliveriesList.jsx
@@ -88,7 +88,7 @@ const DeliveriesList = ({ date, id_ref: idRef, passcode, mode, basePath }) => {
   const formattedDate = `${ (rDate.getDate() > 9) ? rDate.getDate() : (`0${  rDate.getDate() }`)  }/${  (rDate.getMonth() > 8) ? (rDate.getMonth() + 1) : (`0${  rDate.getMonth() + 1 }`)  }/${  rDate.getFullYear() }`;
 
   const googleRouteBaseUrl = 'https://www.google.com/maps/dir';
-  const plusCodes          = [...new Set(routeData.deliveries.map(item => addPlusCodePrefix(item.plus_code)))];
+  const plusCodes          = [ ...new Set(routeData.deliveries.map(item => addPlusCodePrefix(item.plus_code))) ];
   const originForUrl       = encodeURIComponent('The Lockon, Fair Street, Cambridge');
   const googleRouteUrl     = `${ googleRouteBaseUrl }/?api=1&origin=${
     originForUrl


### PR DESCRIPTION
During a recent delivery a stop was omitted from the Google Maps bike route in the app. This appears to be because submitting 10 waypoints or more requires subscription to a higher tier of the Google Maps Platform API: https://developers.google.com/maps/billing-and-pricing/pricing#directions-advanced

Sometimes (though likely not always) the number of waypoints exceeds  the limit of 10 because of duplicate waypoints (for multiple deliveries at the same address).

As you can see, 1 & 2 are duplicates, as are 3, 4 & 5. This means that we are generating 11 waypoints for 8 unique plus codes.

The code I have added should resolve this issue by converting the array of `plus_code` values to a `Set` (which should automatically remove any duplicates. 🤞).

I recommend testing is carried out before this code is merged to `main` as I have not been successful in setting up my local test environment yet.

---

Also, I have taken this opportunity to correct a typo in the repository name in the `README.md` file.